### PR TITLE
New CI

### DIFF
--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -1,0 +1,41 @@
+---
+name: Merges
+
+# yamllint disable-line rule:truthy
+on:
+  push:
+    branches:
+      - main
+
+
+env:
+  DOCKER_BUILDCONTEXT: '.'
+  DOCKER_FILEPATH: 'Dockerfile'
+  DOCKER_REPOSITORY: ${{ github.repository_owner }}
+  DOCKER_IMAGE: ${{ github.event.repository.name }}
+
+jobs:
+  merge:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: docker/setup-buildx-action@v1
+      - uses: docker/metadata-action@v3
+        id: meta
+        with:
+          images: |
+            ghcr.io/${{ env.DOCKER_REPOSITORY }}/${{ env.DOCKER_IMAGE }}
+          tags: |
+            type=ref,event=branch
+            type=sha
+      - uses: docker/login-action@v1
+        with:
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+          registry: ghcr.io
+      - uses: docker/build-push-action@v2
+        with:
+          context: ${{ env.DOCKER_BUILDCONTEXT }}
+          file: ${{ env.DOCKER_FILEPATH }}
+          tags: ${{ steps.meta.outputs.tags }}
+          push: true

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -1,0 +1,35 @@
+---
+name: Pull Requests
+
+# yamllint disable-line rule:truthy
+on:
+  pull_request:
+    branches:
+      - main
+
+
+env:
+  DOCKER_BUILDCONTEXT: '.'
+  DOCKER_FILEPATH: 'Dockerfile'
+  DOCKER_REPOSITORY: ${{ github.repository_owner }}
+  DOCKER_IMAGE: ${{ github.event.repository.name }}
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: docker/setup-buildx-action@v1
+      - uses: docker/metadata-action@v3
+        id: meta
+        with:
+          images: |
+            ghcr.io/${{ env.DOCKER_REPOSITORY }}/${{ env.DOCKER_IMAGE }}
+          tags: |
+            type=ref,event=pr
+      - uses: docker/build-push-action@v2
+        with:
+          context: ${{ env.DOCKER_BUILDCONTEXT }}
+          file: ${{ env.DOCKER_FILEPATH }}
+          tags: ${{ steps.meta.outputs.tags }}
+          push: false

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,43 @@
+---
+name: Releases
+
+# yamllint disable-line rule:truthy
+on:
+  push:
+    tags:
+      - '**'
+
+env:
+  DOCKER_BUILDCONTEXT: '.'
+  DOCKER_FILEPATH: 'Dockerfile'
+  DOCKER_REPOSITORY: ${{ github.repository_owner }}
+  DOCKER_IMAGE: ${{ github.event.repository.name }}
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: docker/setup-buildx-action@v1
+      - uses: docker/metadata-action@v3
+        id: meta
+        with:
+          images: |
+            ghcr.io/${{ env.DOCKER_REPOSITORY }}/${{ env.DOCKER_IMAGE }}
+          tags: |
+            type=ref,event=tag
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}}
+            type=sha
+      - uses: docker/login-action@v1
+        with:
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+          registry: ghcr.io
+      - uses: docker/build-push-action@v2
+        with:
+          context: ${{ env.DOCKER_BUILDCONTEXT }}
+          file: ${{ env.DOCKER_FILEPATH }}
+          tags: ${{ steps.meta.outputs.tags }}
+          push: true


### PR DESCRIPTION
Add new CI please!
# CI/CD on github-actions

This pull request adds The Linux Foundation docker
toolchain for CI/CD workflows on github-actions.

## Toolchain

The CI/CD workflows for this repository are triggered by the following:

* Pull Requests: pull requests against main will verify the project
  container can be built. The container won't be pushed anywhere.
* Merge: Merges to the repository build the docker container and tag it
  with ':latest', and 
  push it to github-packages. 
* Release: On tags, the container is built, tagged with both the
  specified tag and ':latest' and pushed to github-packages.


## Docker Environment Variables

The following variables are available to workflows:
- `$DOCKER_IMAGE`
  Name of the docker image to create
- `$DOCKER_BUILDCONTEXT`
  Path to the build context for the docker image
- `$DOCKER_FILEPATH`
  Path to the Dockerfile being built
- `$DOCKER_REPOSITORY`
  Name of the docker registry repository where the image will be
  distributed


## Updating this Pull Request

If these workflows don't match the needs for your project feel free to
[modify](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/checking-out-pull-requests-locally) them to meet your needs.

Signed-off-by: ITX CI \<itx@linuxfoundation.org\>
on-behalf-of: @linuxfoundation-it \<itx@linuxfoundation.org\>